### PR TITLE
Add translating parser

### DIFF
--- a/prance/__init__.py
+++ b/prance/__init__.py
@@ -253,7 +253,7 @@ class BaseParser(mixins.YAMLMixin, mixins.JSONMixin):
 
 
 class ResolvingParser(BaseParser):
-  """The ResolvingParser extends BaseParser with resolving references."""
+  """The ResolvingParser extends BaseParser with resolving references by inlining."""
 
   def __init__(self, url = None, spec_string = None, lazy = False, **kwargs):
     """
@@ -298,4 +298,14 @@ class ResolvingParser(BaseParser):
     self.specification = resolver.specs
 
     # Now validate - the BaseParser knows the specifics
+    BaseParser._validate(self)
+
+
+class TranslatingParser(BaseParser):
+  def _validate(self):
+    from .util.translator import RefTranslator
+    translator = RefTranslator(self.specification, self.url)
+    translator.translate_references()
+    self.specification = translator.specs
+
     BaseParser._validate(self)

--- a/prance/util/resolver.py
+++ b/prance/util/resolver.py
@@ -1,4 +1,4 @@
-"""This submodule contains a JSON reference resolver."""
+"""This submodule contains a JSON inlining reference resolver."""
 
 __author__ = 'Jens Finkhaeuser'
 __copyright__ = 'Copyright (c) 2016-2018 Jens Finkhaeuser'
@@ -35,7 +35,7 @@ def default_reclimit_handler(limit, parsed_url, recursions = ()):
 
 
 class RefResolver:
-  """Resolve JSON pointers/references in a spec."""
+  """Resolve JSON pointers/references in a spec by inlining."""
 
   def __init__(self, specs, url = None, **options):
     """

--- a/prance/util/translator.py
+++ b/prance/util/translator.py
@@ -1,0 +1,155 @@
+"""This submodule contains a JSON reference translator."""
+
+__author__ = 'Jens Finkhaeuser'
+__copyright__ = 'Copyright © 2021 Štěpán Tomsa'
+__license__ = 'MIT'
+__all__ = ()
+
+import prance.util.url as _url
+
+
+def _reference_key(ref_url, item_path):
+    """
+    Return a portion of the dereferenced URL.
+
+    format - ref-url_obj-path
+    """
+    return ref_url.path.split('/')[-1] + '_' + '_'.join(item_path[1:])
+
+
+def _local_ref(path):
+    url = '#/' + '/'.join(path)
+    return {'$ref': url}
+
+
+class RefTranslator:
+    """
+    Resolve JSON pointers/references in a spec by translation.
+
+    References to objects in other files are copied to the /components/schemas
+    object of the root document, while being translated to point to the the new
+    object locations.
+    """
+
+    def __init__(self, specs, url):
+        """
+        Construct a JSON reference translator.
+
+        The translated specs are in the `specs` member after a call to
+        `translate_references` has been made.
+
+        If a URL is given, it is used as a base for calculating the absolute
+        URL of relative file references.
+
+        :param dict specs: The parsed specs in which to translate any references.
+        :param str url: [optional] The URL to base relative references on.
+        """
+        import copy
+        self.specs = copy.deepcopy(specs)
+
+        self.__strict = True
+        self.__reference_cache = {}
+        self.__collected_references = {}
+
+        if url:
+            self.url = _url.absurl(url)
+            url_key = (_url.urlresource(self.url), self.__strict)
+
+            # If we have a url, we want to add ourselves to the reference cache
+            # - that creates a reference loop, but prevents child resolvers from
+            # creating a new resolver for this url.
+            self.__reference_cache[url_key] = self.specs
+        else:
+            self.url = None
+
+    def translate_references(self):
+        """
+        Iterate over the specification document, performing the translation.
+
+        Traverses over the whole document, adding the referenced object from
+        external files to the /components/schemas object in the root document
+        and translating the references to the new location.
+        """
+        self.specs = self._translate_partial(self.url, self.specs)
+
+        # Add collected references to the root document.
+        if self.__collected_references:
+          if 'components' not in self.specs:
+            self.specs['components'] = {}
+          if 'schemas' not in self.specs['components']:
+            self.specs['components'].update({'schemas': {}})
+
+          self.specs['components']['schemas'].update(self.__collected_references)
+
+    def _dereference(self, ref_url, obj_path):
+        """
+        Dereference the URL and object path.
+
+        Returns the dereferenced object.
+
+        :param mixed ref_url: The URL at which the reference is located.
+        :param list obj_path: The object path within the URL resource.
+        :param tuple recursions: A recursion stack for resolving references.
+        :return: A copy of the dereferenced value, with all internal references
+            resolved.
+        """
+        # In order to start dereferencing anything in the referenced URL, we have
+        # to read and parse it, of course.
+        contents = _url.fetch_url(ref_url, self.__reference_cache, strict=self.__strict)
+
+        # In this inner parser's specification, we can now look for the referenced
+        # object.
+        value = contents
+        if len(obj_path) != 0:
+            from prance.util.path import path_get
+            try:
+                value = path_get(value, obj_path)
+            except (KeyError, IndexError, TypeError) as ex:
+                raise _url.ResolutionError('Cannot resolve reference "%s": %s'
+                                           % (ref_url.geturl(), str(ex)))
+
+        # Deep copy value; we don't want to create recursive structures
+        import copy
+        value = copy.deepcopy(value)
+
+        # Now resolve partial specs
+        value = self._translate_partial(ref_url, value)
+
+        # That's it!
+        return value
+
+    def _translate_partial(self, base_url, partial):
+        changes = dict(tuple(self._translating_iterator(base_url, partial, ())))
+
+        paths = sorted(changes.keys(), key = len)
+
+        from prance.util.path import path_set
+        for path in paths:
+            value = changes[path]
+            if len(path) == 0:
+                partial = value
+            else:
+                path_set(partial, list(path), value, create = True)
+
+        return partial
+
+    def _translating_iterator(self, base_url, partial, path):
+        from prance.util.iterators import reference_iterator
+        for _, ref_string, item_path in reference_iterator(partial):
+            ref_url, obj_path = _url.split_url_reference(base_url, ref_string)
+            full_path = path + item_path
+
+            if ref_url.path == self.url.path:
+                # Reference to the root document.
+                ref_path = obj_path
+            else:
+                # Reference to a non-root document.
+                ref_key = _reference_key(ref_url, obj_path)
+                if ref_key not in self.__collected_references:
+                    self.__collected_references[ref_key] = None
+                    ref_value = self._dereference(ref_url, obj_path)
+                    self.__collected_references[ref_key] = ref_value
+                ref_path = ['components', 'schemas', ref_key]
+
+            ref_obj = _local_ref(ref_path)
+            yield full_path, ref_obj

--- a/tests/specs/translating_parser/different_file_reference_from_file.spec.yaml
+++ b/tests/specs/translating_parser/different_file_reference_from_file.spec.yaml
@@ -1,0 +1,15 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A file reference to a different file reference
+          content:
+            application/json:
+              schema:
+                $ref: 'different_file_reference_from_file_schemas1.spec.yaml#/$defs/RefObject'

--- a/tests/specs/translating_parser/different_file_reference_from_file_schemas1.spec.yaml
+++ b/tests/specs/translating_parser/different_file_reference_from_file_schemas1.spec.yaml
@@ -1,0 +1,4 @@
+---
+$defs:
+  RefObject:
+    $ref: "different_file_reference_from_file_schemas2.spec.yaml#/$defs/PlainObject"

--- a/tests/specs/translating_parser/different_file_reference_from_file_schemas2.spec.yaml
+++ b/tests/specs/translating_parser/different_file_reference_from_file_schemas2.spec.yaml
@@ -1,0 +1,4 @@
+---
+$defs:
+  PlainObject:
+    type: object

--- a/tests/specs/translating_parser/file_reference_from_root.spec.yaml
+++ b/tests/specs/translating_parser/file_reference_from_root.spec.yaml
@@ -1,0 +1,15 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A simple local reference
+          content:
+            application/json:
+              schema:
+                $ref: 'file_reference_from_root_schemas.spec.yaml#/$defs/PlainObject'

--- a/tests/specs/translating_parser/file_reference_from_root_schemas.spec.yaml
+++ b/tests/specs/translating_parser/file_reference_from_root_schemas.spec.yaml
@@ -1,0 +1,4 @@
+---
+$defs:
+  PlainObject:
+    type: object

--- a/tests/specs/translating_parser/local_reference_from_file.spec.yaml
+++ b/tests/specs/translating_parser/local_reference_from_file.spec.yaml
@@ -1,0 +1,15 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A file reference to a local reference
+          content:
+            application/json:
+              schema:
+                $ref: 'local_reference_from_file_schemas.spec.yaml#/$defs/RefObject'

--- a/tests/specs/translating_parser/local_reference_from_file_schemas.spec.yaml
+++ b/tests/specs/translating_parser/local_reference_from_file_schemas.spec.yaml
@@ -1,0 +1,6 @@
+---
+$defs:
+  RefObject:
+    $ref: "#/$defs/PlainObject"
+  PlainObject:
+    type: object

--- a/tests/specs/translating_parser/local_reference_from_root.spec.yaml
+++ b/tests/specs/translating_parser/local_reference_from_root.spec.yaml
@@ -1,0 +1,19 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A simple local reference
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlainObject'
+components:
+  schemas:
+    PlainObject:
+      type: object

--- a/tests/specs/translating_parser/nested_recursive_reference_in_file.spec.yaml
+++ b/tests/specs/translating_parser/nested_recursive_reference_in_file.spec.yaml
@@ -1,0 +1,33 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: >-
+            A local reference to a real-world like object with a recursive local reference deep in a structure in a
+            referenced file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+components:
+  schemas:
+    Response:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResultsItem"
+    ResultsItem:
+      type: object
+      properties:
+        contents:
+          $ref: "#/components/schemas/ReferenceObject"
+    ReferenceObject:
+      $ref: "nested_recursive_reference_in_file_schemas.spec.yaml#/$defs/ComplexObject"

--- a/tests/specs/translating_parser/nested_recursive_reference_in_file_schemas.spec.yaml
+++ b/tests/specs/translating_parser/nested_recursive_reference_in_file_schemas.spec.yaml
@@ -1,0 +1,19 @@
+---
+$defs:
+  ComplexObject:
+    type: object
+    properties:
+      property:
+        $ref: "#/$defs/ComplexObjectProperty"
+  ComplexObjectProperty:
+    type: object
+    properties:
+      recursive:
+        $ref: "#/$defs/RecursiveObject"
+  RecursiveObject:
+    type: object
+    additionalProperties:
+      oneOf:
+        - $ref: "#/$defs/RecursiveObject"
+        - not:
+            type: object

--- a/tests/specs/translating_parser/recursive_reference_in_file.spec.yaml
+++ b/tests/specs/translating_parser/recursive_reference_in_file.spec.yaml
@@ -1,0 +1,15 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A file reference to a local recursive reference
+          content:
+            application/json:
+              schema:
+                $ref: 'recursive_reference_in_file_schemas.spec.yaml#/$defs/RecursiveObject'

--- a/tests/specs/translating_parser/recursive_reference_in_file_schemas.spec.yaml
+++ b/tests/specs/translating_parser/recursive_reference_in_file_schemas.spec.yaml
@@ -1,0 +1,6 @@
+---
+$defs:
+  RecursiveObject:
+    type: object
+    additionalProperties:
+      $ref: "#/$defs/RecursiveObject"

--- a/tests/specs/translating_parser/recursive_reference_in_root.spec.yaml
+++ b/tests/specs/translating_parser/recursive_reference_in_root.spec.yaml
@@ -1,0 +1,21 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A local recursive reference
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecursiveObject'
+components:
+  schemas:
+    RecursiveObject:
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/RecursiveObject"

--- a/tests/specs/translating_parser/root_file_reference_from_file.spec.yaml
+++ b/tests/specs/translating_parser/root_file_reference_from_file.spec.yaml
@@ -1,0 +1,19 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A file reference to a root file reference
+          content:
+            application/json:
+              schema:
+                $ref: 'root_file_reference_from_file_schemas.spec.yaml#/$defs/RefObject'
+components:
+  schemas:
+    PlainObject:
+      type: object

--- a/tests/specs/translating_parser/root_file_reference_from_file_schemas.spec.yaml
+++ b/tests/specs/translating_parser/root_file_reference_from_file_schemas.spec.yaml
@@ -1,0 +1,4 @@
+---
+$defs:
+  RefObject:
+    $ref: "root_file_reference_from_file.spec.yaml#/components/schemas/PlainObject"

--- a/tests/specs/translating_parser/root_file_reference_from_root.spec.yaml
+++ b/tests/specs/translating_parser/root_file_reference_from_root.spec.yaml
@@ -1,0 +1,19 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A file reference to the root file
+          content:
+            application/json:
+              schema:
+                $ref: 'root_file_reference_from_root.spec.yaml#/components/schemas/PlainObject'
+components:
+  schemas:
+    PlainObject:
+      type: object

--- a/tests/specs/translating_parser/same_file_reference_from_file.spec.yaml
+++ b/tests/specs/translating_parser/same_file_reference_from_file.spec.yaml
@@ -1,0 +1,15 @@
+---
+openapi: 3.0.3
+info:
+  title: Test specification for the translating parser
+  version: 0.0.0
+paths:
+  /hosts:
+    get:
+      responses:
+        default:
+          description: A file reference to a same file reference
+          content:
+            application/json:
+              schema:
+                $ref: 'same_file_reference_from_file_schemas.spec.yaml#/$defs/RefObject'

--- a/tests/specs/translating_parser/same_file_reference_from_file_schemas.spec.yaml
+++ b/tests/specs/translating_parser/same_file_reference_from_file_schemas.spec.yaml
@@ -1,0 +1,6 @@
+---
+$defs:
+  RefObject:
+    $ref: "same_file_reference_from_file_schemas.spec.yaml#/$defs/PlainObject"
+  PlainObject:
+    type: object

--- a/tests/test_translating_parser.py
+++ b/tests/test_translating_parser.py
@@ -1,0 +1,183 @@
+from os.path import join
+
+from prance import TranslatingParser
+
+
+class SpecificationTester:
+    """
+    Helper class that tests correct reference translation. Loads a specification file from tests/specs, parses it with
+    the TranslatingParser and provides assertion methods:
+    * assert_schemas to check what’s in /components/schemas.
+    * assert_path_ref to check the $ref of the only operation response in the specification.
+    * assert_schema_ref to check the $ref of a schema in /components/schemas.
+
+    Typical usage:
+    tester = SpecificationTester("my_spec_file")
+    tester.assert_path_ref("some_other_refd_file.spec.yaml_SomeObject")
+    tester.assert_schemas(
+        {"some_other_refd_file.spec.yaml_SomeObject", "some_other_refd_file.spec.yaml_SomeOtherObject"}
+    )
+    tester.assert_schema_ref(
+        "some_other_refd_file.spec.yaml_SomeObject", "some_other_refd_file.spec.yaml_SomeOtherObject",
+    )
+    """
+    @staticmethod
+    def _parse_spec(name):
+        file = f"{name}.spec.yaml"
+        path = join("tests", "specs", "translating_parser", file)
+        parser = TranslatingParser(path)
+        parser.parse()
+        return parser.specification
+
+    @staticmethod
+    def _assert_ref(schema, ref):
+        assert "$ref" in schema
+        assert schema["$ref"] == f"#/components/schemas/{ref}"
+
+    def __init__(self, file):
+        self.specification = self._parse_spec(file)
+
+    def assert_schemas(self, keys):
+        """
+        Asserts schema names in /components/schemas.
+        """
+        assert self.specification["components"]["schemas"].keys() == keys
+
+    def assert_path_ref(self, ref):
+        """
+        Asserts $ref value in /paths/hosts/get/responses/default/content/application/json/schema.
+        """
+        responses = self.specification["paths"]["/hosts"]["get"]["responses"]
+        schema = responses["default"]["content"]["application/json"]["schema"]
+        self._assert_ref(schema, ref)
+
+    def assert_schema_ref(self, key, ref, getter=lambda schema: schema):
+        """
+        Asserts $ref value in /components/schemas/{key}. May use a custom getter function to find the $ref deeper in
+        the schema.
+
+        Example:
+            tester.assert_schema_ref(
+                "SomeComplexObject",
+                "schemas.spec.yaml_SomeOtherObject",
+                lambda schema: schema["properties"]["some_property"]
+            )
+        """
+        schemas = self.specification["components"]["schemas"]
+        assert key in schemas
+        schema = getter(schemas[key])
+        self._assert_ref(schema, ref)
+
+
+def test_local_reference_from_root():
+    tester = SpecificationTester("local_reference_from_root")
+    tester.assert_path_ref("PlainObject")
+    tester.assert_schemas({"PlainObject"})
+
+
+def test_file_reference_from_root():
+    tester = SpecificationTester("file_reference_from_root")
+    tester.assert_path_ref("file_reference_from_root_schemas.spec.yaml_PlainObject")
+    tester.assert_schemas({"file_reference_from_root_schemas.spec.yaml_PlainObject"})
+
+
+def test_local_reference_from_file():
+    tester = SpecificationTester("local_reference_from_file")
+    tester.assert_path_ref("local_reference_from_file_schemas.spec.yaml_RefObject")
+    tester.assert_schemas(
+        {
+            "local_reference_from_file_schemas.spec.yaml_RefObject",
+            "local_reference_from_file_schemas.spec.yaml_PlainObject",
+        }
+    )
+    tester.assert_schema_ref(
+        "local_reference_from_file_schemas.spec.yaml_RefObject",
+        "local_reference_from_file_schemas.spec.yaml_PlainObject",
+    )
+
+
+def test_same_file_reference_from_file():
+    tester = SpecificationTester("same_file_reference_from_file")
+    tester.assert_path_ref("same_file_reference_from_file_schemas.spec.yaml_RefObject")
+    tester.assert_schemas(
+        {
+            "same_file_reference_from_file_schemas.spec.yaml_RefObject",
+            "same_file_reference_from_file_schemas.spec.yaml_PlainObject",
+        }
+    )
+    tester.assert_schema_ref(
+        "same_file_reference_from_file_schemas.spec.yaml_RefObject",
+        "same_file_reference_from_file_schemas.spec.yaml_PlainObject",
+    )
+
+
+def test_different_file_reference_from_file():
+    tester = SpecificationTester("different_file_reference_from_file")
+    tester.assert_path_ref("different_file_reference_from_file_schemas1.spec.yaml_RefObject")
+    tester.assert_schemas(
+        {
+            "different_file_reference_from_file_schemas1.spec.yaml_RefObject",
+            "different_file_reference_from_file_schemas2.spec.yaml_PlainObject",
+        }
+    )
+    tester.assert_schema_ref(
+        "different_file_reference_from_file_schemas1.spec.yaml_RefObject",
+        "different_file_reference_from_file_schemas2.spec.yaml_PlainObject",
+    )
+
+
+def test_root_file_reference_from_file():
+    tester = SpecificationTester("root_file_reference_from_file")
+    tester.assert_path_ref("root_file_reference_from_file_schemas.spec.yaml_RefObject")
+    tester.assert_schemas({"PlainObject", "root_file_reference_from_file_schemas.spec.yaml_RefObject"})
+    tester.assert_schema_ref("root_file_reference_from_file_schemas.spec.yaml_RefObject", "PlainObject")
+
+
+def test_root_file_reference_from_root():
+    tester = SpecificationTester("root_file_reference_from_root")
+    tester.assert_path_ref("PlainObject")
+    tester.assert_schemas({"PlainObject"})
+
+
+def test_recursive_reference_in_root():
+    tester = SpecificationTester("recursive_reference_in_root")
+    tester.assert_schema_ref("RecursiveObject", "RecursiveObject", lambda schema: schema["additionalProperties"])
+
+
+def test_recursive_reference_in_file():
+    tester = SpecificationTester("recursive_reference_in_file")
+    tester.assert_path_ref("recursive_reference_in_file_schemas.spec.yaml_RecursiveObject")
+    tester.assert_schemas({"recursive_reference_in_file_schemas.spec.yaml_RecursiveObject"})
+    tester.assert_schema_ref(
+        "recursive_reference_in_file_schemas.spec.yaml_RecursiveObject",
+        "recursive_reference_in_file_schemas.spec.yaml_RecursiveObject",
+        lambda schema: schema["additionalProperties"]
+    )
+
+
+def test_nested_recursive_reference_in_file():
+    tester = SpecificationTester("nested_recursive_reference_in_file")
+    tester.assert_path_ref("Response")
+    tester.assert_schemas({
+        "Response",
+        "ResultsItem",
+        "ReferenceObject",
+        "nested_recursive_reference_in_file_schemas.spec.yaml_ComplexObject",
+        "nested_recursive_reference_in_file_schemas.spec.yaml_ComplexObjectProperty",
+        "nested_recursive_reference_in_file_schemas.spec.yaml_RecursiveObject",
+    })
+    tester.assert_schema_ref(
+        "nested_recursive_reference_in_file_schemas.spec.yaml_ComplexObject",
+        "nested_recursive_reference_in_file_schemas.spec.yaml_ComplexObjectProperty",
+        lambda schema: schema["properties"]["property"]
+    )
+    tester.assert_schema_ref(
+        "nested_recursive_reference_in_file_schemas.spec.yaml_ComplexObjectProperty",
+        "nested_recursive_reference_in_file_schemas.spec.yaml_RecursiveObject",
+        lambda schema: schema["properties"]["recursive"]
+    )
+    tester.assert_schema_ref(
+        "nested_recursive_reference_in_file_schemas.spec.yaml_RecursiveObject",
+        "nested_recursive_reference_in_file_schemas.spec.yaml_RecursiveObject",
+        lambda schema: schema["additionalProperties"]["oneOf"][0]
+    )


### PR DESCRIPTION
Added a Translating Parser as an alternative to the Resolving Parser. The Translating Parser resolves the references by adding them to the _/components/schemas_ object of the root document instead of inlining them in place of the original _$ref_. That results in less repetition, better memory usage and allows for recursive objects.
