### PR TITLE
Fix URL scheme "python"

### DIFF
--- a/changelog.d/104.bugfix
+++ b/changelog.d/104.bugfix
@@ -1,0 +1,1 @@
+RefResolver will again accept and if instructed resolve references using the "python" URL scheme.

--- a/prance/util/resolver.py
+++ b/prance/util/resolver.py
@@ -181,7 +181,7 @@ class RefResolver:
     """Return whether the URL should not be dereferenced."""
     if ref_url.scheme.startswith('http'):
       return (self.__resolve_types & RESOLVE_HTTP) == 0
-    elif ref_url.scheme == 'file':
+    elif ref_url.scheme == 'file' or ref_url.scheme == 'python':
       # Internal references
       if base_url.path == ref_url.path:
         return (self.__resolve_types & RESOLVE_INTERNAL) == 0

--- a/tests/specs/with_externals.yaml
+++ b/tests/specs/with_externals.yaml
@@ -65,6 +65,10 @@ paths:
           description: Expected response to a valid request
           schema:
             $ref: 'http://finkhaeuser.de/projects/prance/petstore.yaml#/definitions/Pet'
+        "203":
+          description: Expected response to a valid request
+          schema:
+            $ref: 'python://tests/specs/petstore.yaml#/definitions/Pet'
         default:
           description: unexpected error
           schema:

--- a/tests/test_util_resolver.py
+++ b/tests/test_util_resolver.py
@@ -308,6 +308,9 @@ def test_issue_23_partial_resolution_all(mock_get):
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '200', 'schema'))
   assert '$ref' not in val
 
+  val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '203', 'schema'))
+  assert '$ref' not in val
+
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', 'default', 'schema'))
   assert '$ref' not in val
 
@@ -336,6 +339,9 @@ def test_issue_23_partial_resolution_internal():
   assert '$ref' in val
 
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '200', 'schema'))
+  assert '$ref' in val
+
+  val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '203', 'schema'))
   assert '$ref' in val
 
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', 'default', 'schema'))
@@ -367,6 +373,9 @@ def test_issue_23_partial_resolution_files():
 
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '200', 'schema'))
   assert '$ref' in val
+
+  val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '203', 'schema'))
+  assert '$ref' not in val
 
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', 'default', 'schema'))
   assert '$ref' in val
@@ -431,6 +440,9 @@ def test_issue_23_partial_resolution_http(mock_get):
 
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '200', 'schema'))
   assert '$ref' not in val
+
+  val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '203', 'schema'))
+  assert '$ref' in val
 
   val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', 'default', 'schema'))
   assert '$ref' in val
@@ -601,3 +613,19 @@ def test_issue_205_swagger_resolution_failure():
   )
   # test will raise an exception
   res.resolve_references()
+
+@patch('requests.get')
+def test_resolve_package_ref(mock_get):
+  mock_get.side_effect = mock_get_petstore
+
+  specs = get_specs('tests/specs/with_externals.yaml')
+  res = resolver.RefResolver(specs,
+      fs.abspath('tests/specs/with_externals.yaml'),
+      resolve_types = resolver.RESOLVE_FILES
+      )
+  res.resolve_references()
+
+  from prance.util.path import path_get
+
+  val = path_get(res.specs, ('paths', '/pets/{petId}', 'get', 'responses', '203', 'schema'))
+  assert 'required' in val


### PR DESCRIPTION
The introduction of `_skip_reference` in `prance.util.resolver.RefResolver` in b7357b0f broke the `python` URL scheme which is documented in the [Prance documentation](https://prance.readthedocs.io/en/latest/api/prance.util.url.html) and implemented [here](https://github.com/RonnyPfannschmidt/prance/blob/main/prance/util/url.py#L175-L186). Resolving schemata with such references will currently raise a `ValueError` exception.

This PR extends `_skip_reference` to recognize these URLs again. They are handled the same way as `file` URLs.
